### PR TITLE
Banner link to old docs

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -7,45 +7,49 @@
 
 const React = require('react');
 
-
 class Footer extends React.Component {
   render() {
     return (
-      <footer className="nav-footer" id="footer">
-        <section className="sitemap">
-          <div className="footerSection">
-            <h5>Foundation</h5>
-            <a href="https://www.nervos.org/">
-              About Us
-            </a>
-          </div>
-          <div className="footerSection">
-            <h5>Developer</h5>
-            <a href="https://github.com/nervosnetwork">
-              GitHub
-            </a>
-            <a href="https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0002-ckb/0002-ckb.md">
-              Whitepaper
-            </a>
-            <a href="https://github.com/nervosnetwork/rfcs">
-              RFCs
-            </a>
-          </div>
-          <div className="footerSection socialLinks">
-            {this.props.config.socialLinks.map((item) => (
-              <a href={item.url} className="socialLink" key={item.label}>
-                <img src={`${this.props.config.baseUrl}${item.icon}`} />
-                {item.label}
+      <>
+        <footer className="nav-footer" id="footer">
+          <section className="sitemap">
+            <div className="footerSection">
+              <h5>Foundation</h5>
+              <a href="https://www.nervos.org/">
+                About Us
               </a>
-            ))}
-          </div>
-        </section>
-        <section className="copyright">
-          {this.props.config.copyright && (
-            <span>{this.props.config.copyright}</span>
-          )}
-        </section>
-      </footer>
+            </div>
+            <div className="footerSection">
+              <h5>Developer</h5>
+              <a href="https://github.com/nervosnetwork">
+                GitHub
+              </a>
+              <a href="https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0002-ckb/0002-ckb.md">
+                Whitepaper
+              </a>
+              <a href="https://github.com/nervosnetwork/rfcs">
+                RFCs
+              </a>
+            </div>
+            <div className="footerSection socialLinks">
+              {this.props.config.socialLinks.map((item) => (
+                <a href={item.url} className="socialLink" key={item.label}>
+                  <img src={`${this.props.config.baseUrl}${item.icon}`} />
+                  {item.label}
+                </a>
+              ))}
+            </div>
+          </section>
+          <section className="copyright">
+            {this.props.config.copyright && (
+              <span>{this.props.config.copyright}</span>
+            )}
+          </section>
+        </footer>
+        <div className="oldSiteLink">
+          <span>Note we've completely rebuilt Nervos Doc site!</span> <span>For the old doc site, please see <a href={this.props.config.oldDocSiteUrl}>docs-old</a></span>.
+        </div>
+      </>
     );
   }
 }

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -46,8 +46,10 @@ class Footer extends React.Component {
             )}
           </section>
         </footer>
-        <div className="oldSiteLink">
-          <span>Note we've completely rebuilt Nervos Doc site!</span> <span>For the old doc site, please see <a href={this.props.config.oldDocSiteUrl}>docs-old</a></span>.
+        <div id="oldSiteLink">
+          <div>
+            <span>Note we've completely rebuilt Nervos Doc site! </span><span>For the old doc site, please see <a href={this.props.config.oldDocSiteUrl}>docs-old</a>.</span>
+          </div>
         </div>
       </>
     );

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -76,7 +76,7 @@ const siteConfig = {
   },
 
   // Add custom scripts here that would be placed in <script> tags.
-  scripts: [],
+  scripts: ['/js/extra.js'],
 
   // NOTE: This is configured per documentation of docusaurus:
   // https://docusaurus.io/docs/en/search

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -20,6 +20,8 @@ const siteConfig = {
   baseUrl: '/',
   cname: 'docs-new.nervos.org',
 
+  oldDocSiteUrl: 'https://docs-old.nervos.org',
+
   // Used for publishing and more
   projectName: 'docs-new',
   organizationName: 'nervosnetwork',

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -74,7 +74,7 @@ const siteConfig = {
   },
 
   // Add custom scripts here that would be placed in <script> tags.
-  scripts: ['https://buttons.github.io/buttons.js'],
+  scripts: [],
 
   // NOTE: This is configured per documentation of docusaurus:
   // https://docusaurus.io/docs/en/search

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -314,6 +314,24 @@ article li {
   margin-right: 6px;
 }
 
+/* Banner link to legacy doc site */
+
+#oldSiteLink {
+  position: fixed;
+  height: 40px;
+  width: 100%;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #333;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.fixedHeaderContainer {
+  margin-top: 40px;
+}
+
 /* Responsive */
 
 @media only screen and (min-width: 1024px) {
@@ -368,6 +386,19 @@ article li {
 
   .card {
     margin: 10px 20px;
+  }
+
+  #oldSiteLink {
+    height: 60px;
+  }
+
+  #oldSiteLink span {
+    display: block;
+    text-align: center;
+  }
+
+  .fixedHeaderContainer {
+    margin-top: 60px;
   }
 }
 

--- a/website/static/js/extra.js
+++ b/website/static/js/extra.js
@@ -1,0 +1,4 @@
+window.addEventListener('load', function() {
+  var banner = document.querySelector('#oldSiteLink');
+  document.querySelector('body').prepend(banner);
+});


### PR DESCRIPTION
Note: the legacy site url is configured as `https://docs-old.nervos.org` which is **NOT** accessible ATM. Should it require update/change we can simple change `oldDocSiteUrl` from `siteConfig.js`.

The banner HTML is put inside `Footer.js`, which is the only point we can customize (docusaurus v1.x). HTML element placed there is difficult to position at our need, so I added an `extra.js` which moves the banner to top on page load.

### PC
<img width="1499" alt="Screen Shot 2020-07-02 at 12 27 02" src="https://user-images.githubusercontent.com/1391/86313243-a555cc80-bc5f-11ea-907e-36a73658ed02.png">

### Mobile
<img width="671" alt="Screen Shot 2020-07-02 at 12 26 34" src="https://user-images.githubusercontent.com/1391/86313247-a8e95380-bc5f-11ea-987c-289ea2a1384b.png">
