### PR TITLE
docs: fix typos

### DIFF
--- a/website/docs/basics/concepts/ckb-vm.md
+++ b/website/docs/basics/concepts/ckb-vm.md
@@ -25,7 +25,7 @@ Developers have complete flexibility to rely on existing open-source libraries r
 
 Any programming language that can target RISC-V can be used natively for Nervos development. Use your existing tooling, favorite IDEs, and debug tools. There is no need to rely on immature and untested tools; use whatever is best for the job.
 
-Nervos CKB offers native SDKs in a growing number of well-known general-purpose programming languages, such as Javascript, Rust, and C. Direct support for emerging smart contract languages, such as Solidity, Vyper, and Plutus is also planned.
+Nervos CKB offers native SDKs in a growing number of well-known general-purpose programming languages, such as JavaScript, Rust, and C. Direct support for emerging smart contract languages, such as Solidity, Vyper, and Plutus is also planned.
 
 ## Further Reading
 

--- a/website/docs/essays/rfcs.md
+++ b/website/docs/essays/rfcs.md
@@ -17,7 +17,7 @@ This tour provides  short introduction on our RFCs and links, hope it will be he
 
 This document provides a high-level walkthrough of all parts of the Nervos Network, with a focus on how they work together to support the overall vision of the network. 
 
-###  [Nervos CKB: A Common Knowledge Base for Crypto-Economy](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0002-ckb/0002-ckb.md)
+### [Nervos CKB: A Common Knowledge Base for Crypto-Economy](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0002-ckb/0002-ckb.md)
 
 This is Nervos CKB whitepaper, provides an overview of the Nervos Common Knowledge Base (CKB), a public permissionless blockchain and layer 1 of Nervos. 
 
@@ -35,7 +35,7 @@ This RFC introduces the crypto-economics of Nervos CKB. Nervos CKB is the base l
 
 ### [Data Structures](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0019-data-structures/0019-data-structures.md)
 
-This RFC explains all the basic data structures used in CKB, includes [Cell](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0019-data-structures/0019-data-structures.md#Cell),[Script](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0019-data-structures/0019-data-structures.md#Script),[Transaction](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0019-data-structures/0019-data-structures.md#Transaction) and [Block](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0019-data-structures/0019-data-structures.md#Block).
+This RFC explains all the basic data structures used in CKB, includes [Cell](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0019-data-structures/0019-data-structures.md#Cell), [Script](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0019-data-structures/0019-data-structures.md#Script), [Transaction](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0019-data-structures/0019-data-structures.md#Transaction) and [Block](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0019-data-structures/0019-data-structures.md#Block).
 
 ### [CKB Consensus Protocol](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0020-ckb-consensus-protocol/0020-ckb-consensus-protocol.md)
 


### PR DESCRIPTION
1. Javascript -> JavaScript
2. comma after space
