### PR TITLE
fix: anchor positioning

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -332,6 +332,11 @@ article li {
   margin-top: 40px;
 }
 
+a.anchor {
+  /* 120px = origial 80px + margin-top 40px */
+  top: -120px; 
+}
+
 /* Responsive */
 
 @media only screen and (min-width: 1024px) {


### PR DESCRIPTION
The anchor positioning is 40px(from old site announcement bar) more than it actually is, resulting in the header not being visible when the link is clicked.
This issue is particularly prominent in long articles like: 
https://docs.nervos.org/docs/basics/glossary#block-time