### PR TITLE
fix: the preview pages which rendered by GitHub flavored Markdown

### DIFF
--- a/website/docs/labs/sudtbycapsule.md
+++ b/website/docs/labs/sudtbycapsule.md
@@ -53,12 +53,14 @@ capsule check
 ```
 <details>
 <summary>(click here to view response)</summary>
+
 ```bash
 ------------------------------
 docker    installed
 ckb-cli    installed
 ------------------------------
 ```
+
 </details>
 
 
@@ -69,6 +71,7 @@ capsule new my-sudt
 ```
 <details>
 <summary>(click here to view response)</summary>
+
 ```bash
 New project "my-sudt"
 Created file "capsule.toml"
@@ -82,6 +85,7 @@ Created tests
      Created binary (application) `tests` package
 Done
 ```
+
 </details>
 
 
@@ -92,10 +96,12 @@ ls my-sudt
 ```
 <details>
 <summary>(click here to view response)</summary>
+
 ```bash
 
 build  capsule.toml  Cargo.toml  contracts  deployment.toml  migrations  README.md  tests
 ```
+
 </details>
 
 The default contract is under `my-sudt/contracts/my-sudt` directory which is a normal cargo project:
@@ -105,10 +111,12 @@ ls my-sudt/contracts/my-sudt
 ```
 <details>
 <summary>(click here to view response)</summary>
+
 ```bash
 
 Cargo.toml  src
 ```
+
 </details>
 
 You can open `my-sudt/contracts/my-sudt/src/main.rs` to see some pre-generated code:
@@ -200,6 +208,7 @@ capsule build
 
 <details>
 <summary>(click here to view response)</summary>
+
 ```bash
 
 Building contract my-sudt
@@ -215,6 +224,7 @@ Building contract my-sudt
     Finished dev [unoptimized + debuginfo] target(s) in 8.73s
 Done
 ```
+
 </details>
 
 
@@ -225,10 +235,12 @@ ls build/debug
 ```
 <details>
 <summary>(click here to view response)</summary>
+
 ```bash
 
 my-sudt
 ```
+
 </details>
 
 


### PR DESCRIPTION
Between a Html tag and a Markdown code block tag, there should be a blank line.

Check [original page of "Write an SUDT Script by Capsule"] and [fixed page of it] to see the differences.
Check this article on [Nervos CKB docs site].

Run the follow code to fix the preview pages which rendered by GitHub flavored Markdown.

```bash
find . -name "*.md" | while read f; do
    sed -i ':a;N;N;N;$!ba;s@\(</summary>\)\n\(```\)@\1\n\n\2@g' "${f}"
    sed -i ':a;N;N;N;$!ba;s@\(```\)\n\(</details>\)@\1\n\n\2@g' "${f}"
done
```

[original page of "Write an SUDT Script by Capsule"]: https://github.com/nervosnetwork/docs-new/blob/896ffb3c143ae60ec88eb806678a9b6d8bd1a75c/website/docs/labs/sudtbycapsule.md
[fixed page of it]: https://github.com/yangby-cryptape/docs-new/blob/effd2b582a30a3ce9aeb4807d143ef35fd33fce2/website/docs/labs/sudtbycapsule.md
[Nervos CKB docs site]: https://docs.nervos.org/docs/labs/sudtbycapsule
